### PR TITLE
Fix crash when reading a local file in a production environment

### DIFF
--- a/hxl/input.py
+++ b/hxl/input.py
@@ -560,7 +560,7 @@ def open_url_or_file(url_or_filename, input_options):
         try:
             info = os.stat(url_or_filename)
             content_length = info.st_size
-            file = io.open(url_or_filename, 'rb+')
+            file = io.open(url_or_filename, 'rb')
             fileno = file.fileno()
             return (file, mime_type, file_ext, encoding, content_length, fileno,)
         except Exception as e:


### PR DESCRIPTION
When using this code in an environment where the python libraries are in a virtualenv where the files are readable but not writable will crash due to a change that was made to use a permissions string of 'rb+'. This file shouldn't be updated by this reader code (I think), so revert it back to 'rb'.